### PR TITLE
Support running app on port other than 80 with docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ umls.zip
 .DS_Store
 node_modules/
 public/js/dist/
+.env

--- a/README.md
+++ b/README.md
@@ -27,6 +27,18 @@ From the root directory of `fhir-validator-app`:
 * Build the image, using `docker-compose build`
 * Run the compose file, using `docker-compose up`. This will run both the standalone validator app, as well as the [fhir-validator-wrapper](https://github.com/inferno-community/fhir-validator-wrapper) Docker container required to do external validation.
 
+To avoid conflicts the published container ports can be customized using a `.env` file in root directory of `fhir-validator-app`, for example:
+
+```
+# default 80
+FHIR_VALIDATOR_APP_PORT=8888
+
+# default 4567
+FHIR_VALIDATOR_SERVICE_PORT=9999
+```
+
+
+
 ## Contact Us
 The Inferno development team can be reached by email at
 inferno@groups.mitre.org.  Inferno also has a dedicated [HL7 FHIR chat

--- a/create_config.sh
+++ b/create_config.sh
@@ -2,7 +2,7 @@
 
 cat << EOF
 CONFIG = {
-  validatorBasePath: "$VALIDATOR_BASE_PATH",
+  validatorBasePath: "$VALIDATOR_BASE_PATH/",
   externalValidatorUrl: "$EXTERNAL_VALIDATOR_URL",
 };
 EOF

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,13 +6,13 @@ services:
     depends_on:
       - fhir_validator_service
     environment:
-      EXTERNAL_VALIDATOR_URL: http://localhost:4567
+      EXTERNAL_VALIDATOR_URL: http://localhost:${FHIR_VALIDATOR_SERVICE_PORT-4567}
       VALIDATOR_BASE_PATH: /validator
     ports:
-      - "80:80"
+      - "${FHIR_VALIDATOR_APP_PORT-80}:80"
   fhir_validator_service:
     image: infernocommunity/fhir-validator-service:latest
     volumes:
       - ./igs:/home/igs/package
     ports:
-      - "4567:4567"
+      - "${FHIR_VALIDATOR_SERVICE_PORT-4567}:4567"


### PR DESCRIPTION
* Users can create a .env file to override the default 80/4567 published ports
* Add trailing slash to navbar-brand href to prevent nginx from redirecting to port 80 when override is in effect
