### PR TITLE
FI-2012: Update app name

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -72,7 +72,7 @@
       }
     </style>
 
-    <title>FHIR Validator</title>
+    <title>Inferno Resource Validator</title>
   </head>
 
   <body>

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -20,13 +20,13 @@ export function App(): ReactElement {
     <>
       <nav className="navbar navbar-expand-lg navbar-light bg-light">
         <a className="navbar-brand" href={config('validatorBasePath') ?? '/'}>
-          FHIR Validator
+          Inferno Resource Validator
         </a>
       </nav>
       <div className="container py-5">
         <Switch>
           <Route exact path="/">
-            <h1>FHIR Validator</h1>
+            <h1>Inferno Resource Validator</h1>
             <ValidatorForm />
           </Route>
           <Route path={RESULTS_PATH}>
@@ -37,7 +37,7 @@ export function App(): ReactElement {
       <nav className="navbar fixed-bottom navbar-light bg-light" style={{ zIndex: 'auto' }}>
         <a
           className="navbar-link"
-          href="https://github.com/inferno-community/fhir-validator-app"
+          href="https://github.com/inferno-framework/fhir-validator-app"
           target="_blank"
           rel="noreferrer"
         >
@@ -45,7 +45,7 @@ export function App(): ReactElement {
         </a>
         <a
           className="navbar-link"
-          href="https://github.com/inferno-community/fhir-validator-app/issues"
+          href="https://github.com/inferno-framework/fhir-validator-app/issues"
           target="_blank"
           rel="noreferrer"
         >
@@ -74,7 +74,7 @@ export function App(): ReactElement {
               </button>
             </div>
             <div className="modal-body">
-              FHIR Validator App Version: {appVersion}
+              Inferno Resource Validator App Version: {appVersion}
               <br />
               FHIR Validation Service Version: {validatorVersion}
             </div>

--- a/src/components/ResourceCard.tsx
+++ b/src/components/ResourceCard.tsx
@@ -16,7 +16,7 @@ export function ResourceCard(): ReactElement {
           name="resource"
           state={formState['resource']}
           dispatch={(action: Action): void => dispatch({ name: 'resource', ...action })}
-          textLabel="Paste your FHIR resource here:"
+          textLabel="Paste your HL7® FHIR® resource here:"
           fileLabel="Or upload a resource in a file:"
           validator={resourceValidator}
         />


### PR DESCRIPTION
# Summary
A few simple text changes:
 - change the display name of the app to "Inferno Resource Validator" so the name doesn't mention FHIR
 - updates the first instance of "FHIR" on the page to say "HL7® FHIR®"
 - updates the links to point to github/inferno-framework instead of inferno-community. The old links still worked but I'm not sure how long redirects are guaranteed to work for.

# Testing Guidance
Make sure the text is correct?
