### PR TITLE
FI-1223: Parse /version endpoint returning JSON

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -11,7 +11,8 @@ import { TRACKING_ID } from 'utils/ga';
 export type AppState = FormState & { results?: ValidationResult };
 
 export function App(): ReactElement {
-  const [validatorVersion, setVersion] = useState('');
+  const [wrapperVersion, setWrapperVersion] = useState('');
+  const [hl7ValidatorVersion, setHl7ValidatorVersion] = useState('');
 
   if (window.location.hostname === 'inferno.healthit.gov') {
     ReactGA.initialize(TRACKING_ID);
@@ -20,7 +21,12 @@ export function App(): ReactElement {
 
   useEffect(() => {
     let aborted = false;
-    void getVersion().then((version) => !aborted && setVersion(version));
+    getVersion().then((version) => {
+      if (!aborted) {
+        setWrapperVersion(version['inferno-framework/fhir-validator-wrapper']);
+        setHl7ValidatorVersion(version['org.hl7.fhir.validation']);
+      }
+    });
     return (): void => void (aborted = true);
   }, []);
 
@@ -84,7 +90,9 @@ export function App(): ReactElement {
             <div className="modal-body">
               Inferno Resource Validator App Version: {appVersion}
               <br />
-              FHIR Validation Service Version: {validatorVersion}
+              FHIR Validation Wrapper Version: {wrapperVersion}
+              <br />
+              HL7® Validator Version: {hl7ValidatorVersion}
             </div>
           </div>
         </div>

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -21,7 +21,7 @@ export function App(): ReactElement {
 
   useEffect(() => {
     let aborted = false;
-    getVersion().then((version) => {
+    void getVersion().then((version) => {
       if (!aborted) {
         setWrapperVersion(version['inferno-framework/fhir-validator-wrapper']);
         setHl7ValidatorVersion(version['org.hl7.fhir.validation']);

--- a/src/components/test-utils.tsx
+++ b/src/components/test-utils.tsx
@@ -83,7 +83,11 @@ export const mockFetch = (): void => {
           'hl7.fhir.us.core': 'http://packages2.fhir.org/packages/hl7.fhir.us.core/3.1.0',
         });
     } else if (path.endsWith('/version')) {
-      response.text = (): Promise<string> => Promise.resolve('5.0.11-SNAPSHOT');
+      response.json = (): Promise<Record<string, string>> =>
+        Promise.resolve({
+          'org.hl7.fhir.validation': '5.6.93',
+          'inferno-framework/fhir-validator-wrapper': '2.2.1',
+        });
     } else {
       response.ok = false;
       response.statusText = '404 Not Found';

--- a/src/models/HL7Validator.tsx
+++ b/src/models/HL7Validator.tsx
@@ -116,4 +116,4 @@ export const getProfilesByIg = (): Promise<Record<string, string[]>> =>
   validatorFetch('GET', 'profiles-by-ig').then(parseJson) as Promise<Record<string, string[]>>;
 
 export const getVersion = (): Promise<Record<string, string>> =>
-  validatorFetch('GET', 'version').then(parseJson);
+  validatorFetch('GET', 'version').then(parseJson) as Promise<Record<string, string>>;

--- a/src/models/HL7Validator.tsx
+++ b/src/models/HL7Validator.tsx
@@ -115,5 +115,5 @@ export const loadPackage = async (file: File): Promise<IgResponse> =>
 export const getProfilesByIg = (): Promise<Record<string, string[]>> =>
   validatorFetch('GET', 'profiles-by-ig').then(parseJson) as Promise<Record<string, string[]>>;
 
-export const getVersion = (): Promise<string> =>
-  validatorFetch('GET', 'version').then((response) => response.text());
+export const getVersion = (): Promise<Record<string, string>> =>
+  validatorFetch('GET', 'version').then(parseJson);


### PR DESCRIPTION
# Summary
Updates the version logic to parse a JSON response from the validator `/version` endpoint instead of using just text. Corresponding PR on the validator wrapper is https://github.com/inferno-framework/fhir-validator-wrapper/pull/62

Note this is not currently backwards compatible, if the wrapper is an older version and still returns just text, the version string will be blank in that case. If that's critical for this app I can fix that, just thought this was cleaner.

# Testing Guidance
Click the "Version 1.0.0" link in the bottom right of the page to bring up the version modal.
